### PR TITLE
Track full Oauth response in the session

### DIFF
--- a/hq_superset/oauth.py
+++ b/hq_superset/oauth.py
@@ -14,6 +14,7 @@ class CommCareSecurityManager(SupersetSecurityManager):
 
     def set_oauth_session(self, provider, oauth_response):
         super().set_oauth_session(provider, oauth_response)
-        # The default FAB implementation only stores the access_token and disregards `refresh_token` and `expires_at`
-        #   keep a track of refresh_token so that new access_token can be obtained
+        # The default FAB implementation only stores the access_token and disregards
+        #   other part of the oauth_response such as `refresh_token` and `expires_at`
+        #   keep a track of full response so that refresh_token is not lost for latter use
         session['oauth_response'] = oauth_response

--- a/hq_superset/oauth.py
+++ b/hq_superset/oauth.py
@@ -1,5 +1,8 @@
 import logging
+import superset
+import time
 from flask import session
+from requests.exceptions import HTTPError
 from superset.security import SupersetSecurityManager
 
 class CommCareSecurityManager(SupersetSecurityManager):
@@ -17,4 +20,56 @@ class CommCareSecurityManager(SupersetSecurityManager):
         # The default FAB implementation only stores the access_token and disregards
         #   other part of the oauth_response such as `refresh_token` and `expires_at`
         #   keep a track of full response so that refresh_token is not lost for latter use
-        session['oauth_response'] = oauth_response
+        #
+        # Sample oauth_response
+        # {
+        #     'access_token': 'AcLBaXPC7HvJiefUYECBWOd4rCN6L9',
+        #     'expires_in': 900,
+        #     'token_type': 'Bearer',
+        #     'scope': 'view',
+        #     'reports:view access_apis',
+        #     'refresh_token': 'kXU2Xo4RLn1UCYJMX2KWaic1kxI0PP',
+        #     'expires_at': 1650872906
+        # }
+        session["oauth_response"] = oauth_response
+
+
+class OAuthSessionExpired(Exception):
+    pass
+
+
+def get_valid_cchq_oauth_token():
+    # Returns a valid working oauth access_token
+    #   May raise `OAuthSessionExpired`, if a valid working token is not found
+    #   The user needs to re-auth using CommCareHQ to get valid tokens
+    oauth_response = session["oauth_response"]
+    if "access_token" not in oauth_response:
+        raise OAuthSessionExpired(
+            "access_token not found in oauth_response, possibly because "
+            "the user didn't do an OAuth Login yet"
+        )
+
+    # If token hasn't expired yet, return it
+    expires_at = oauth_response.get("expires_at")
+    if expires_at > int(time.time()):
+        return oauth_response
+    provider = superset.appbuilder.sm.oauth_remotes["commcare"]
+
+    # If the token has expired, get a new token using refresh_token
+    refresh_token = oauth_response.get("refresh_token")
+    if not refresh_token:
+        raise OAuthSessionExpired(
+            "access_token is expired but a refresh_token is not found in oauth_response"
+        )
+    try:
+        refresh_response = provider._get_oauth_client().refresh_token(
+            provider.access_token_url,
+            refresh_token=refresh_token
+        )
+        superset.appbuilder.sm.set_oauth_session(provider, refresh_response)
+        return refresh_response
+    except HTTPError:
+        # If the refresh token too expired raise exception.
+        raise OAuthSessionExpired(
+            "OAuth refresh token has expired. User need to re-authorize the OAuth Application"
+        )

--- a/hq_superset/oauth.py
+++ b/hq_superset/oauth.py
@@ -1,4 +1,5 @@
 import logging
+from flask import session
 from superset.security import SupersetSecurityManager
 
 class CommCareSecurityManager(SupersetSecurityManager):
@@ -10,3 +11,9 @@ class CommCareSecurityManager(SupersetSecurityManager):
             user = self.appbuilder.sm.oauth_remotes[provider].get("api/v0.5/identity/", token=response).json()
             logging.debug("user - {}".format(user))
             return user
+
+    def set_oauth_session(self, provider, oauth_response):
+        super().set_oauth_session(provider, oauth_response)
+        # The default FAB implementation only stores the access_token and disregards `refresh_token` and `expires_at`
+        #   keep a track of refresh_token so that new access_token can be obtained
+        session['oauth_response'] = oauth_response


### PR DESCRIPTION
On Signup, FAB only stores access_token into flask session (see [code](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/security/manager.py#L552)). This is enough for signup only OAuth integrations, but integrations needing to access Oauth endpoints at a latter point need the refresh_token as well to refresh the access token. This PR stores the full oauth response on the server side session (which is encrypted).

@akashkj @proteusvacuum @kaapstorm  