### PR TITLE
Add a view to refresh HQ UCR based dataset

### DIFF
--- a/hq_superset/__init__.py
+++ b/hq_superset/__init__.py
@@ -8,4 +8,6 @@ def patch_superset_config(config):
 def flask_app_mutator(app):
     # Import the views (which assumes the app is initialized) here
     # return
-    pass
+    from . import views
+    from superset.extensions import appbuilder
+    appbuilder.add_view(views.HQDatasourceView, 'Update HQ Datasource')

--- a/hq_superset/oauth.py
+++ b/hq_superset/oauth.py
@@ -14,6 +14,7 @@ class CommCareSecurityManager(SupersetSecurityManager):
 
     def set_oauth_session(self, provider, oauth_response):
         super().set_oauth_session(provider, oauth_response)
-        # The default FAB implementation only stores the access_token and disregards `refresh_token` and `expires_at`
-        #   keep a track of refresh_token so that new access_token can be obtained
+        # The default FAB implementation only stores the access_token and disregards
+        #   other part of the oauth_response such as `refresh_token` and `expires_at`
+        #   keep a track of full response so that refresh_token is not lost for latter use
         session['oauth_response'] = oauth_response

--- a/hq_superset/oauth.py
+++ b/hq_superset/oauth.py
@@ -1,5 +1,8 @@
 import logging
+import superset
+import time
 from flask import session
+from requests.exceptions import HTTPError
 from superset.security import SupersetSecurityManager
 
 class CommCareSecurityManager(SupersetSecurityManager):
@@ -17,4 +20,56 @@ class CommCareSecurityManager(SupersetSecurityManager):
         # The default FAB implementation only stores the access_token and disregards
         #   other part of the oauth_response such as `refresh_token` and `expires_at`
         #   keep a track of full response so that refresh_token is not lost for latter use
-        session['oauth_response'] = oauth_response
+        #
+        # Sample oauth_response
+        # {
+        #     'access_token': 'AcLBaXPC7HvJiefUYECBWOd4rCN6L9',
+        #     'expires_in': 900,
+        #     'token_type': 'Bearer',
+        #     'scope': 'view',
+        #     'reports:view access_apis',
+        #     'refresh_token': 'kXU2Xo4RLn1UCYJMX2KWaic1kxI0PP',
+        #     'expires_at': 1650872906
+        # }
+        session["oauth_response"] = oauth_response
+
+
+class OAuthSessionExpired(Exception):
+    pass
+
+
+def get_valid_cchq_oauth_token():
+    # Returns a valid working oauth access_token
+    #   May raise `OAuthSessionExpired`, if a valid working token is not found
+    #   The user needs to re-auth using CommCareHQ to get valid tokens
+    oauth_response = session["oauth_response"]
+    if "access_token" not in oauth_response:
+        raise OAuthSessionExpired(
+            "access_token not found in oauth_response, possibly because "
+            "the user didn't do an OAuth Login yet"
+        )
+
+    # If token hasn't expired yet, return it
+    expires_at = oauth_response.get("expires_at")
+    if expires_at > int(time.time()):
+        return oauth_response
+    provider = superset.appbuilder.sm.oauth_remotes["commcare"]
+
+    # If the token has expired, get a new token using refresh_token
+    refresh_token = oauth_response.get("refresh_token")
+    if not refresh_token:
+        raise OAuthSessionExpired(
+            "access_token is expired but a refresh_token is not found in oauth_response"
+        )
+    try:
+        refresh_response = provider._get_oauth_client().refresh_token(
+            provider.access_token_url,
+            refresh_token=refresh_token
+        )
+        superset.appbuilder.sm.set_oauth_session(provider, refresh_response)
+        return refresh_response
+    except HTTPError:
+        # If the refresh token too expired raise exception.
+        raise OAuthSessionExpired(
+            "OAuth refresh token has expired. User need to re-authorize the OAuth Application"
+        )

--- a/hq_superset/oauth.py
+++ b/hq_superset/oauth.py
@@ -1,4 +1,5 @@
 import logging
+from flask import session
 from superset.security import SupersetSecurityManager
 
 class CommCareSecurityManager(SupersetSecurityManager):
@@ -10,3 +11,9 @@ class CommCareSecurityManager(SupersetSecurityManager):
             user = self.appbuilder.sm.oauth_remotes[provider].get("api/v0.5/identity/", token=response).json()
             logging.debug("user - {}".format(user))
             return user
+
+    def set_oauth_session(self, provider, oauth_response):
+        super().set_oauth_session(provider, oauth_response)
+        # The default FAB implementation only stores the access_token and disregards `refresh_token` and `expires_at`
+        #   keep a track of refresh_token so that new access_token can be obtained
+        session['oauth_response'] = oauth_response

--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -1,0 +1,3 @@
+
+def get_datasource_export_url(domain, datasource_id):
+    return f"a/{domain}/configurable_reports/data_sources/export/{datasource_id}?format=csv"

--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -1,3 +1,17 @@
+import sqlalchemy
 
 def get_datasource_export_url(domain, datasource_id):
     return f"a/{domain}/configurable_reports/data_sources/export/{datasource_id}?format=csv"
+
+
+def get_ucr_database():
+    # Todo; get actual DB once that's implemented
+    return db.session.query(Database).filter_by(database_name="HQ Data").one()
+
+
+def create_schema_if_not_exists(schema_name):
+    # Create a schema in the database where HQ's UCR data is stored
+    database = get_ucr_database()
+    engine = database.get_sqla_engine()
+    if not engine.dialect.has_schema(engine, schema_name):
+        engine.execute(sqlalchemy.schema.CreateSchema(schema_name))

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -1,0 +1,128 @@
+import pandas as pd
+import superset
+from flask import url_for, render_template, redirect, request, session, g
+from flask_appbuilder import expose, BaseView
+from flask_appbuilder.security.decorators import has_access, permission_name
+from flask_login import current_user
+from io import BytesIO
+from superset import db
+from superset.connectors.sqla.models import SqlaTable
+from superset.sql_parse import Table
+from superset.models.core import Database
+from zipfile import ZipFile
+from .utils import get_datasource_export_url
+from .oauth import get_valid_cchq_oauth_token
+
+
+class HQDatasourceView(BaseView):
+
+    def __init__(self):
+        self.route_base = "/a/<domain>/datasource/"
+        super().__init__()
+
+    @expose("/update/<datasource_id>", methods=["POST"])
+    def create_or_update(self, domain, datasource_id):
+        # Fetches data for a datasource from HQ and creates/updates a superset table
+        from .oauth import get_valid_cchq_oauth_token
+        res = refresh_hq_datasource(domain, datasource_id)
+        return res
+
+
+class CCHQApiException(Exception):
+    pass
+
+
+def refresh_hq_datasource(domain, datasource_id):
+    # This method pulls the data from CommCareHQ and creates/replaces the
+    #   corresponding Superset dataset
+    datasource_url = get_datasource_export_url(domain, datasource_id)
+    provider = superset.appbuilder.sm.oauth_remotes["commcare"]
+    oauth_token = get_valid_cchq_oauth_token()
+    response = provider.get(datasource_url, token=oauth_token)
+    if response.status_code != 200:
+        # Todo; logging
+        raise CCHQApiException("Error downloading the UCR export from HQ")
+    zipfile = ZipFile(BytesIO(response.content))
+    filename = zipfile.namelist()[0]
+    # Upload to table
+    database = get_ucr_database()
+    schema = get_domain_db_schema(domain)
+    csv_table = Table(table=datasource_id, schema=schema)
+
+    try:
+        df = pd.concat(
+            pd.read_csv(
+                chunksize=1000,
+                filepath_or_buffer=zipfile.open(filename),
+                encoding="utf-8",
+                # Todo; make date parsing work
+                parse_dates=True,
+                infer_datetime_format=True,
+                keep_default_na=True,
+            )
+        )
+
+        database.db_engine_spec.df_to_sql(
+            database,
+            csv_table,
+            df,
+            to_sql_kwargs={
+                "chunksize": 1000,
+                "if_exists": "replace",
+            },
+        )
+
+        # Connect table to the database that should be used for exploration.
+        # E.g. if hive was used to upload a csv, presto will be a better option
+        # to explore the table.
+        expore_database = database
+        explore_database_id = database.explore_database_id
+        if explore_database_id:
+            expore_database = (
+                db.session.query(Database)
+                .filter_by(id=explore_database_id)
+                .one_or_none()
+                or database
+            )
+
+        sqla_table = (
+            db.session.query(SqlaTable)
+            .filter_by(
+                table_name=csv_table.table,
+                schema=csv_table.schema,
+                database_id=expore_database.id,
+            )
+            .one_or_none()
+        )
+
+        if sqla_table:
+            sqla_table.fetch_metadata()
+        if not sqla_table:
+            sqla_table = SqlaTable(table_name=csv_table.table)
+            sqla_table.database = expore_database
+            sqla_table.database_id = database.id
+            sqla_table.user_id = g.user.get_id()
+            sqla_table.schema = csv_table.schema
+            sqla_table.fetch_metadata()
+            db.session.add(sqla_table)
+        db.session.commit()
+    except Exception as ex:  # pylint: disable=broad-except
+        db.session.rollback()
+        raise ex
+
+    # Todo;
+    # Assign the datasource:view access for the user's domain-role
+    # Todo; could return the ID of the created datasource
+    return "success"
+
+
+
+def get_ucr_database():
+    # Todo; get actual DB once that's implemented
+    return db.session.query(Database).filter_by(database_name='HQ Data').one()
+
+
+def get_domain_db_schema(domain):
+    # Todo; get actual domain schema
+    return 'public'
+

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -10,7 +10,7 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.sql_parse import Table
 from superset.models.core import Database
 from zipfile import ZipFile
-from .utils import get_datasource_export_url
+from .utils import get_datasource_export_url, get_ucr_database
 from .oauth import get_valid_cchq_oauth_token
 
 
@@ -114,12 +114,6 @@ def refresh_hq_datasource(domain, datasource_id):
     # Assign the datasource:view access for the user's domain-role
     # Todo; could return the ID of the created datasource
     return "success"
-
-
-
-def get_ucr_database():
-    # Todo; get actual DB once that's implemented
-    return db.session.query(Database).filter_by(database_name='HQ Data').one()
 
 
 def get_domain_db_schema(domain):


### PR DESCRIPTION
This PR adds a view that that takes the domain and config_id via the URL and re-pulls the datasource when called. Below are the implementation details. I was able to test this locally with success.

- The domain and config_id can be passed via the URL (for e.g. http://localhost:8088/a/test-domain/datasource/update/49f40d61cadcc69ede285982f4001e82). 
- The dataset is replaced on each refresh.

There is few more todos in here, but I wanted to get this out to get any initial feedback. The todos are

- Assign a read permission on the created/updated dataset to the user's domain specific role.
- Create a schema for the domain if it doesn't exist
- Make date parsing work.
- Let the view return the url or the DB model ID of the dataset.
- Unit tests.

Note that the Oauth part is in a separate PR as well https://github.com/dimagi/hq_superset/pull/4

@kaapstorm @akashkj @proteusvacuum 