### PR TITLE
Handle array datatype columns in datasets

### DIFF
--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -67,15 +67,19 @@ def get_column_dtypes(datasource_defn):
     }
     column_dtypes = {'doc_id': 'string'}
     date_columns = ['inserted_at']
+    array_type_columns = []
     for ind in datasource_defn['configured_indicators']:
         indicator_datatype = ind.get('datatype', 'string')
-        if pandas_dtypes[indicator_datatype] == 'datetime64[ns]':
+
+        if indicator_datatype == "array":
+            array_type_columns.append(ind['column_id'])
+        elif pandas_dtypes[indicator_datatype] == 'datetime64[ns]':
             # the dtype datetime64[ns] is not supported for parsing,
             # pass this column using parse_dates instead
             date_columns.append(ind['column_id'])
         else:
             column_dtypes[ind['column_id']] = pandas_dtypes[indicator_datatype]
-    return column_dtypes, date_columns
+    return column_dtypes, date_columns, array_type_columns
 
 
 def parse_date(date_str):

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -124,11 +124,7 @@ def convert_to_array(string_array):
     """
 
     def array_is_falsy(array_values):
-        if not array_values:
-            return True
-        if len(array_values) == 1 and array_values[0] is None:
-            return True
-        return False
+        return not array_values or array_values == [None]
 
     try:
         array_values = ast.literal_eval(string_array)

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -126,7 +126,7 @@ def convert_to_array(string_array):
     def array_is_falsy(array_values):
         if not array_values:
             return True
-        if array_values[0] is None:
+        if len(array_values) == 1 and array_values[0] is None:
             return True
         return False
 


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2208)

Handle datasource array datatype. Arrays will be stored in postgres as a collection of strings. I'm not sure if we can assume that it will always be strings?

As far as testing goes, I could pull the data from postgres through SQL Lab in superset and view it. Not sure if there is other tests I can also do?