### PR TITLE
Remove datasource file after task success as well

### DIFF
--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -14,5 +14,5 @@ def refresh_hq_datasource_task(domain, datasource_id, display_name, export_path,
         refresh_hq_datasource(domain, datasource_id, display_name, export_path, datasource_defn, user_id)
     except Exception:
         AsyncImportHelper(domain, datasource_id).mark_as_complete()
-        os.remove(export_path)
         raise
+    os.remove(export_path)


### PR DESCRIPTION
I have noticed that the datasource csv files aren't getting deleted after async import. This one deletes so that the files don't build up.

@kaapstorm @Charl1996 