### PR TITLE
Cs/sc 3069 subscribe to ds changes

### DIFF
--- a/hq_superset/__init__.py
+++ b/hq_superset/__init__.py
@@ -14,11 +14,12 @@ def flask_app_mutator(app):
     # Import the views (which assumes the app is initialized) here
     # return
     from superset.extensions import appbuilder
-
-    from . import hq_domain, views
+    from . import hq_domain, views, api
 
     appbuilder.add_view(views.HQDatasourceView, 'Update HQ Datasource', menu_cond=lambda *_: False)
     appbuilder.add_view(views.SelectDomainView, 'Select a Domain', menu_cond=lambda *_: False)
+    appbuilder.add_api(api.OAuth)
+
     appbuilder.add_view(views.DataSetChangeAPI, 'DataSet Change API', menu_cond=lambda *_: False)
     app.before_request_funcs.setdefault(None, []).append(
         hq_domain.before_request_hook

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -90,7 +90,7 @@ class OAuth(BaseApi):
         try:
             response = authorization.create_token_response()
         except NoResultFound:
-            return jsonify({"error": "Invalid credentials"}), 401
+            return jsonify({"error": "Invalid client"}), 401
 
         if response.status_code >= 400:
             return response

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -1,0 +1,93 @@
+import json
+from datetime import datetime, timedelta
+from flask_appbuilder.api import expose, BaseApi
+from flask import jsonify
+from superset import db
+from authlib.integrations.flask_oauth2 import AuthorizationServer
+from authlib.oauth2.rfc6749 import grants
+from superset.extensions import appbuilder
+from werkzeug.security import check_password_hash
+from authlib.integrations.sqla_oauth2 import OAuth2ClientMixin
+
+ONE_DAY_SECONDS = 60*60*24
+app = appbuilder.app
+
+
+class HQClient(db.Model, OAuth2ClientMixin):
+    __tablename__ = 'hq_oauth_client'
+
+    domain = db.Column(db.String(255), primary_key=True)
+
+    def check_client_secret(self, client_secret):
+        return check_password_hash(self.client_secret, client_secret)
+
+    def revoke_tokens(self):
+        tokens = db.session.execute(
+            db.select(Token).filter_by(client_id=self.client_id, revoked=False)
+        ).all()
+        for token, in tokens:
+            token.revoked = True
+            db.session.add(token)
+        db.session.commit()
+
+
+class Token(db.Model):
+    __tablename__ = 'hq_oauth_token'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    client_id = db.Column(db.String(40), nullable=False, index=True)
+    token_type = db.Column(db.String(40))
+    access_token = db.Column(db.String(255), nullable=False, unique=True)
+    scope = db.Column(db.String(255))  # could be the domain data sources
+    revoked = db.Column(db.Boolean, default=False)
+    issued_at = db.Column(db.DateTime, default=datetime.utcnow)
+    expires_at = db.Column(db.DateTime)
+
+
+def query_client(client_id):
+    return db.session.execute(
+        db.select(HQClient).filter_by(client_id=client_id)
+    ).scalar_one()
+
+
+def save_token(token, request):
+    client = request.client
+    client.revoke_tokens()
+
+    expires_at = datetime.utcnow() + timedelta(seconds=ONE_DAY_SECONDS)
+    tok = Token(
+        client_id=client.client_id,
+        expires_at=expires_at,
+        access_token=token['access_token'],
+        token_type=token['token_type'],
+    )
+    db.session.add(tok)
+    db.session.commit()
+
+
+class HQClientCredentialsGrant(grants.ClientCredentialsGrant):
+
+    def validate_requested_scope(self, *args, **kwargs):
+        # Todo: check domain
+        return True
+
+
+authorization = AuthorizationServer(
+    app=app,
+    query_client=query_client,
+    save_token=save_token,
+)
+authorization.register_grant(HQClientCredentialsGrant)
+
+
+class OAuth(BaseApi):
+
+    @expose("/token", methods=('POST',))
+    def issue_access_token(self):
+        response = authorization.create_token_response()
+        if response.status_code == 401:
+            return jsonify({'error': 'Invalid client credentials'}), 401
+
+        data = json.loads(response.data.decode("utf-8"))
+        data['expires_in'] = ONE_DAY_SECONDS
+        return jsonify(data)

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -69,13 +69,18 @@ def save_token(token, request):
 
 
 class HQClientCredentialsGrant(grants.ClientCredentialsGrant):
-
     def validate_requested_scope(self, *args, **kwargs):
         if not self.request.scope == self.client.domain:
             raise InvalidScopeError()
 
 
-authorization = AuthorizationServer(
+class HQAuthorizationServer(AuthorizationServer):
+    def generate_token(self, *args, **kwargs):
+        kwargs['expires_in'] = ONE_DAY_SECONDS
+        return super().generate_token(*args, **kwargs)
+
+
+authorization = HQAuthorizationServer(
     app=app,
     query_client=query_client,
     save_token=save_token,

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -1,11 +1,10 @@
 import json
-from authlib.oauth2.rfc6749.errors import InvalidScopeError
 from sqlalchemy.orm.exc import NoResultFound
 from datetime import datetime, timedelta
 from flask_appbuilder.api import expose, BaseApi
 from flask import jsonify
 from superset import db
-from authlib.integrations.flask_oauth2 import AuthorizationServer, ResourceProtector, current_token
+from authlib.integrations.flask_oauth2 import AuthorizationServer, ResourceProtector
 from authlib.oauth2.rfc6749 import grants
 from authlib.oauth2.rfc6750 import BearerTokenValidator
 from superset.extensions import appbuilder

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -10,8 +10,6 @@ from authlib.oauth2.rfc6750 import BearerTokenValidator
 from superset.extensions import appbuilder
 from hq_superset.models import HQClient, Token
 
-ONE_DAY_SECONDS = 60*60*24
-
 require_oauth = ResourceProtector()
 app = appbuilder.app
 
@@ -24,7 +22,7 @@ def save_token(token, request):
     client = request.client
     client.revoke_tokens()
 
-    expires_at = datetime.utcnow() + timedelta(seconds=ONE_DAY_SECONDS)
+    expires_at = datetime.utcnow() + timedelta(days=1)
     tok = Token(
         client_id=client.client_id,
         expires_at=expires_at,

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -36,12 +36,6 @@ def save_token(token, request):
     db.session.commit()
 
 
-class HQAuthorizationServer(AuthorizationServer):
-    def generate_token(self, *args, **kwargs):
-        kwargs['expires_in'] = ONE_DAY_SECONDS
-        return super().generate_token(*args, **kwargs)
-
-
 class HQBearerTokenValidator(BearerTokenValidator):
     def authenticate_token(self, token_string):
         return db.session.query(Token).filter_by(access_token=token_string).first()
@@ -49,7 +43,7 @@ class HQBearerTokenValidator(BearerTokenValidator):
 
 require_oauth.register_token_validator(HQBearerTokenValidator())
 
-authorization = HQAuthorizationServer(
+authorization = AuthorizationServer(
     app=app,
     query_client=query_client,
     save_token=save_token,
@@ -74,5 +68,4 @@ class OAuth(BaseApi):
             return response
 
         data = json.loads(response.data.decode("utf-8"))
-        data['expires_in'] = ONE_DAY_SECONDS
         return jsonify(data)

--- a/hq_superset/hq_domain.py
+++ b/hq_superset/hq_domain.py
@@ -29,9 +29,9 @@ DOMAIN_EXCLUDED_VIEWS = [
 ]
 
 def is_user_admin():
-    # from superset.views.base import is_user_admin
-    # return is_user_admin()
-    return True
+    from superset.views.base import is_user_admin
+    return is_user_admin()
+
 
 def ensure_domain_selected():
     # Check if a hq_domain cookie is set

--- a/hq_superset/hq_domain.py
+++ b/hq_superset/hq_domain.py
@@ -29,8 +29,9 @@ DOMAIN_EXCLUDED_VIEWS = [
 ]
 
 def is_user_admin():
-    from superset.views.base import is_user_admin
-    return is_user_admin()
+    # from superset.views.base import is_user_admin
+    # return is_user_admin()
+    return True
 
 def ensure_domain_selected():
     # Check if a hq_domain cookie is set

--- a/hq_superset/hq_requests.py
+++ b/hq_superset/hq_requests.py
@@ -1,0 +1,48 @@
+import superset
+from hq_superset.oauth import get_valid_cchq_oauth_token
+
+
+class HqUrl:
+    @classmethod
+    def datasource_export_url(cls, domain, datasource_id):
+        return f"a/{domain}/configurable_reports/data_sources/export/{datasource_id}/?format=csv"
+
+    @classmethod
+    def datasource_list_url(cls, domain):
+        return f"a/{domain}/api/v0.5/ucr_data_source/"
+
+    @classmethod
+    def datasource_details_url(cls, domain, datasource_id):
+        return f"a/{domain}/api/v0.5/ucr_data_source/{datasource_id}/"
+
+    @classmethod
+    def subscribe_to_datasource_url(cls, domain, datasource_id):
+        return f"a/{domain}/configurable_reports/data_sources/subscribe/{datasource_id}/"
+
+
+class HQRequest:
+
+    def __init__(self, url):
+        self.url = url
+
+    @property
+    def oauth_token(self):
+        return get_valid_cchq_oauth_token()
+
+    @property
+    def commcare_provider(self):
+        return superset.appbuilder.sm.oauth_remotes["commcare"]
+
+    @property
+    def api_base_url(self):
+        return self.commcare_provider.api_base_url
+
+    @property
+    def absolute_url(self):
+        return f"{self.api_base_url}{self.url}"
+
+    def get(self):
+        return self.commcare_provider.get(self.url, token=self.oauth_token)
+
+    def post(self, data):
+        return self.commcare_provider.post(self.url, data=data, token=self.oauth_token)

--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -49,7 +49,7 @@ class HQClient(db.Model, OAuth2ClientMixin):
     @classmethod
     def create_domain_client(cls, domain: str):
         alphabet = string.ascii_letters + string.digits
-        client_secret = ''.join(secrets.choice(alphabet) for i in range(32))
+        client_secret = ''.join(secrets.choice(alphabet) for i in range(64))
 
         client = HQClient(
             domain=domain,

--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -65,7 +65,6 @@ class Token(db.Model):
     client_id = db.Column(db.String(40), nullable=False, index=True)
     token_type = db.Column(db.String(40))
     access_token = db.Column(db.String(255), nullable=False, unique=True)
-    scope = db.Column(db.String(255))
     revoked = db.Column(db.Boolean, default=False)
     issued_at = db.Column(db.DateTime, default=datetime.utcnow)
     expires_at = db.Column(db.DateTime)
@@ -82,4 +81,4 @@ class Token(db.Model):
         return self.revoked
 
     def get_scope(self):
-        return self.scope
+        return ''

--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -1,5 +1,11 @@
+import uuid
 from dataclasses import dataclass
 from typing import Any, Literal
+
+from datetime import datetime
+from superset import db
+from authlib.integrations.sqla_oauth2 import OAuth2ClientMixin
+from werkzeug.security import check_password_hash, generate_password_hash
 
 
 @dataclass
@@ -11,3 +17,51 @@ class DataSetChange:
     def __post_init__(self):
         if 'doc_id' not in self.data:
             raise TypeError("'data' missing required key: 'doc_id'")
+
+
+class HQClient(db.Model, OAuth2ClientMixin):
+    __tablename__ = 'hq_oauth_client'
+
+    domain = db.Column(db.String(255), primary_key=True)
+
+    def check_client_secret(self, client_secret):
+        return check_password_hash(self.client_secret, client_secret)
+
+    def revoke_tokens(self):
+        tokens = db.session.execute(
+            db.select(Token).filter_by(client_id=self.client_id, revoked=False)
+        ).all()
+        for token, in tokens:
+            token.revoked = True
+            db.session.add(token)
+        db.session.commit()
+
+    @classmethod
+    def get_by_domain(cls, domain):
+        return db.session.query(HQClient).filter_by(domain=domain).first()
+
+    @classmethod
+    def create_domain_client(cls, domain: str):
+        client_secret = str(uuid.uuid4())
+        client = HQClient(
+            domain=domain,
+            client_id=str(uuid.uuid4()),
+            client_secret=generate_password_hash(client_secret),
+        )
+        db.session.add(client)
+        db.session.commit()
+
+        return client.client_id, client_secret
+
+
+class Token(db.Model):
+    __tablename__ = 'hq_oauth_token'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    client_id = db.Column(db.String(40), nullable=False, index=True)
+    token_type = db.Column(db.String(40))
+    access_token = db.Column(db.String(255), nullable=False, unique=True)
+    scope = db.Column(db.String(255))  # could be the domain data sources
+    revoked = db.Column(db.Boolean, default=False)
+    issued_at = db.Column(db.DateTime, default=datetime.utcnow)
+    expires_at = db.Column(db.DateTime)

--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -81,7 +81,13 @@ class Token(db.Model):
         return datetime.utcnow() > self.expires_at
 
     def is_revoked(self):
+        """
+        The require_oauth ResourceProtector needs this method to be defined
+        """
         return self.revoked
 
     def get_scope(self):
+        """
+        The require_oauth ResourceProtector needs this method to be defined
+        """
         return self.scope

--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -52,6 +52,8 @@ class HQClient(db.Model, OAuth2ClientMixin):
             client_id=str(uuid.uuid4()),
             client_secret=generate_password_hash(client_secret),
         )
+        client.set_client_metadata({"grant_types": ["client_credentials"]})
+
         db.session.add(client)
         db.session.commit()
 
@@ -68,6 +70,7 @@ class Token(db.Model):
     revoked = db.Column(db.Boolean, default=False)
     issued_at = db.Column(db.DateTime, default=datetime.utcnow)
     expires_at = db.Column(db.DateTime)
+    scope = db.Column(db.String(255))
 
     @property
     def domain(self):
@@ -81,4 +84,4 @@ class Token(db.Model):
         return self.revoked
 
     def get_scope(self):
-        return ''
+        return self.scope

--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -1,4 +1,6 @@
 import uuid
+import string
+import secrets
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -46,7 +48,9 @@ class HQClient(db.Model, OAuth2ClientMixin):
 
     @classmethod
     def create_domain_client(cls, domain: str):
-        client_secret = str(uuid.uuid4())
+        alphabet = string.ascii_letters + string.digits
+        client_secret = ''.join(secrets.choice(alphabet) for i in range(32))
+
         client = HQClient(
             domain=domain,
             client_id=str(uuid.uuid4()),

--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -16,3 +16,34 @@ def refresh_hq_datasource_task(domain, datasource_id, display_name, export_path,
         AsyncImportHelper(domain, datasource_id).mark_as_complete()
         raise
     os.remove(export_path)
+
+
+@celery_app.task(name='subscribe_to_hq_datasource_task')
+def subscribe_to_hq_datasource_task(domain, datasource_id):
+    from hq_superset.hq_requests import HQRequest, HqUrl
+    from hq_superset.models import HQClient
+    from superset.config import BASE_URL
+
+    if HQClient.get_by_domain(domain) is None:
+        hq_request = HQRequest(
+            url=HqUrl.subscribe_to_datasource_url(domain, datasource_id)
+        )
+
+        client_id, client_secret = HQClient.create_domain_client(domain)
+
+        response = hq_request.post({
+            'webhook_url': f'{BASE_URL}/hq_webhook/change/',
+            'token_url': f'{BASE_URL}/oauth/token',
+            'client_id': client_id,
+            'client_secret': client_secret,
+        })
+        if response.status_code == 201:
+            return
+        if response.status_code < 500:
+            logger.error(
+                f"Failed to subscribe to data source {datasource_id} due to the following issue: {response.content}"
+            )
+        if response.status_code >= 500:
+            logger.exception(
+                f"Failed to subscribe to data source {datasource_id} due to a remote server error"
+            )

--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -41,7 +41,7 @@ def subscribe_to_hq_datasource_task(domain, datasource_id):
             return
         if response.status_code < 500:
             logger.error(
-                f"Failed to subscribe to data source {datasource_id} due to the following issue: {response.content}"
+                f"Failed to subscribe to data source {datasource_id} due to the following issue: {response.data}"
             )
         if response.status_code >= 500:
             logger.exception(

--- a/hq_superset/tests/base_test.py
+++ b/hq_superset/tests/base_test.py
@@ -40,14 +40,14 @@ class HQDBTestCase(SupersetTestCase):
 
     def tearDown(self):
         # Drop HQ DB Schemas
-        engine = self.hq_db.get_sqla_engine()
-        with engine.connect() as connection:
-            results = connection.execute(text("SELECT schema_name FROM information_schema.schemata"))
-            domain_schemas = []
-            for schema, in results.fetchall():
-                if schema.startswith(DOMAIN_PREFIX):
-                    domain_schemas.append(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE; COMMIT;')
-            if domain_schemas:
-                sql = "; ".join(domain_schemas) + ";"
-                connection.execute(text(sql))
+        with self.hq_db.get_sqla_engine_with_context() as engine:
+            with engine.connect() as connection:
+                results = connection.execute(text("SELECT schema_name FROM information_schema.schemata"))
+                domain_schemas = []
+                for schema, in results.fetchall():
+                    if schema.startswith(DOMAIN_PREFIX):
+                        domain_schemas.append(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE; COMMIT;')
+                if domain_schemas:
+                    sql = "; ".join(domain_schemas) + ";"
+                    connection.execute(text(sql))
         super(HQDBTestCase, self).tearDown()

--- a/hq_superset/tests/test_hq_domain.py
+++ b/hq_superset/tests/test_hq_domain.py
@@ -120,11 +120,11 @@ class TestDomainSyncUtil(HQDBTestCase):
 
     def test_schema_gets_created(self):
         schema_name = get_schema_name_for_domain(self.domain)
-        engine = self.hq_db.get_sqla_engine()
-        self.assertFalse(
-            engine.dialect.has_schema(engine, schema_name),
-        )
-        DomainSyncUtil._ensure_schema_created(self.domain)
-        self.assertTrue(
-            engine.dialect.has_schema(engine, schema_name),
-        )
+        with self.hq_db.get_sqla_engine_with_context() as engine:
+            self.assertFalse(
+                engine.dialect.has_schema(engine, schema_name),
+            )
+            DomainSyncUtil._ensure_schema_created(self.domain)
+            self.assertTrue(
+                engine.dialect.has_schema(engine, schema_name),
+            )

--- a/hq_superset/tests/test_views.py
+++ b/hq_superset/tests/test_views.py
@@ -196,7 +196,7 @@ class TestViews(HQDBTestCase):
         self.assertTrue('/domain/list' in response.request.path)
         self.logout(client)
 
-    @patch('hq_superset.views.get_valid_cchq_oauth_token', return_value={})
+    @patch('hq_superset.oauth.get_valid_cchq_oauth_token', return_value={})
     def test_datasource_list(self, *args):
         def _do_assert(datasources):
             self.assert_template_used("hq_datasource_list.html")
@@ -228,14 +228,13 @@ class TestViews(HQDBTestCase):
                 'ds1'
             )
 
-    @patch('hq_superset.views.get_valid_cchq_oauth_token', return_value={})
+    @patch('hq_superset.oauth.get_valid_cchq_oauth_token', return_value={})
     @patch('hq_superset.views.os.remove')
     def test_trigger_datasource_refresh(self, *args):
         from hq_superset.views import (
             ASYNC_DATASOURCE_IMPORT_LIMIT_IN_BYTES,
             trigger_datasource_refresh,
         )
-
         domain = 'test1'
         ds_name = 'ds_name'
         file_path = '/file_path'
@@ -275,7 +274,7 @@ class TestViews(HQDBTestCase):
             None
         )
 
-    @patch('hq_superset.views.get_valid_cchq_oauth_token', return_value={})
+    @patch('hq_superset.oauth.get_valid_cchq_oauth_token', return_value={})
     def test_download_datasource(self, *args):
         from hq_superset.views import download_datasource
         ucr_id = self.oauth_mock.test1_datasources['objects'][0]['id']
@@ -285,7 +284,7 @@ class TestViews(HQDBTestCase):
             self.assertEqual(size, len(pickle.dumps(TEST_UCR_CSV_V1)))
         os.remove(path)
 
-    @patch('hq_superset.views.get_valid_cchq_oauth_token', return_value={})
+    @patch('hq_superset.oauth.get_valid_cchq_oauth_token', return_value={})
     def test_refresh_hq_datasource(self, *args):
 
         client = self.app.test_client()

--- a/hq_superset/tests/test_views.py
+++ b/hq_superset/tests/test_views.py
@@ -148,11 +148,11 @@ class TestViews(HQDBTestCase):
             self.assertTrue('hq_domain' not in response.request.cookies)
 
     def _assert_pg_schema_exists(self, domain, exists):
-        engine = self.hq_db.get_sqla_engine()
-        self.assertEqual(
-            engine.dialect.has_schema(engine, get_schema_name_for_domain(domain)),
-            exists
-        )
+        with self.hq_db.get_sqla_engine_with_context() as engine:
+            self.assertEqual(
+                engine.dialect.has_schema(engine, get_schema_name_for_domain(domain)),
+                exists
+            )
 
     def test_redirects_to_domain_select_after_login(self):
         with self.app.test_client() as client:
@@ -275,10 +275,21 @@ class TestViews(HQDBTestCase):
         )
 
     @patch('hq_superset.oauth.get_valid_cchq_oauth_token', return_value={})
-    def test_download_datasource(self, *args):
+    @patch('hq_superset.tasks.subscribe_to_hq_datasource_task.delay')
+    @patch('hq_superset.hq_requests.HQRequest.get')
+    def test_download_datasource(self, hq_request_get_mock, subscribe_task_mock, *args):
         from hq_superset.views import download_datasource
+        hq_request_get_mock.return_value = MockResponse(
+            json_data=TEST_UCR_CSV_V1,
+            status_code=200,
+        )
         ucr_id = self.oauth_mock.test1_datasources['objects'][0]['id']
-        path, size = download_datasource(self.oauth_mock, '_', 'test1', ucr_id)
+        path, size = download_datasource('test1', ucr_id)
+
+        subscribe_task_mock.assert_called_once_with(
+            'test1',
+            ucr_id,
+        )
         with open(path, 'rb') as f:
             self.assertEqual(pickle.load(f), TEST_UCR_CSV_V1)
             self.assertEqual(size, len(pickle.dumps(TEST_UCR_CSV_V1)))
@@ -291,7 +302,7 @@ class TestViews(HQDBTestCase):
         
         ucr_id = self.oauth_mock.test1_datasources['objects'][0]['id']
         ds_name = "ds1"
-        with patch("hq_superset.views.get_datasource_file") as csv_mock, \
+        with patch("hq_superset.utils.get_datasource_file") as csv_mock, \
             self.app.test_client() as client:
             self.login(client)
             client.get('/domain/select/test1/', follow_redirects=True)
@@ -304,15 +315,15 @@ class TestViews(HQDBTestCase):
                 self.assertEqual(datasets['result'][0]['schema'], get_schema_name_for_domain('test1'))
                 self.assertEqual(datasets['result'][0]['table_name'], ucr_id)
                 self.assertEqual(datasets['result'][0]['description'], ds_name)
-                engine = self.hq_db.get_sqla_engine()
-                with engine.connect() as connection:
-                    result = connection.execute(text(
-                        'SELECT doc_id FROM hqdomain_test1.test1_ucr1'
-                    )).fetchall()
-                    self.assertEqual(
-                        result,
-                        expected_output
-                    )
+                with self.hq_db.get_sqla_engine_with_context() as engine:
+                    with engine.connect() as connection:
+                        result = connection.execute(text(
+                            'SELECT doc_id FROM hqdomain_test1.test1_ucr1'
+                        )).fetchall()
+                        self.assertEqual(
+                            result,
+                            expected_output
+                        )
                 # Check that updated dataset is reflected in the list view
                 client.get('/hq_datasource/list/', follow_redirects=True)
                 self.assert_context('ucr_id_to_pks', {'test1_ucr1': 1})

--- a/hq_superset/tests/utils.py
+++ b/hq_superset/tests/utils.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from sqlalchemy.orm.exc import NoResultFound
 
-from hq_superset.utils import HQ_DB_CONNECTION_NAME, get_hq_database
+from hq_superset.utils import HQ_DB_CONNECTION_NAME, get_hq_database, CCHQApiException
 
 
 class UnitTestingRequired(Exception):
@@ -28,9 +28,8 @@ def setup_hq_db():
 
     try:
         get_hq_database()
-    except NoResultFound:
+    except CCHQApiException:
         CreateDatabaseCommand(
-            None, 
             {
                 'sqlalchemy_uri': superset.app.config.get('HQ_DATA_DB'),
                 'engine': 'PostgreSQL', 

--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -211,7 +211,7 @@ def download_datasource(domain, datasource_id):
 
     filename = f"{datasource_id}_{datetime.now()}.zip"
     path = os.path.join(superset.config.SHARED_DIR, filename)
-    breakpoint()
+
     with open(path, "wb") as f:
         f.write(response.content)
 

--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -3,6 +3,7 @@ import os
 from contextlib import contextmanager
 from datetime import date, datetime
 from zipfile import ZipFile
+from hq_superset.tasks import subscribe_to_hq_datasource_task
 
 import pandas
 import sqlalchemy
@@ -214,7 +215,7 @@ def download_datasource(domain, datasource_id):
     with open(path, "wb") as f:
         f.write(response.content)
 
-    # subscribe to datasource
+    subscribe_to_hq_datasource_task.delay(domain, datasource_id)
 
     return path, len(response.content)
 

--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -161,9 +161,9 @@ class DomainSyncUtil:
     def _ensure_schema_created(domain):
         schema_name = get_schema_name_for_domain(domain)
         database = get_hq_database()
-        engine = database.get_sqla_engine()
-        if not engine.dialect.has_schema(engine, schema_name):
-            engine.execute(sqlalchemy.schema.CreateSchema(schema_name))
+        with database.hq_db.get_sqla_engine_with_context() as engine:
+            if not engine.dialect.has_schema(engine, schema_name):
+                engine.execute(sqlalchemy.schema.CreateSchema(schema_name))
 
     def re_eval_roles(self, existing_roles, new_domain_role):
         # Filter out other domain roles
@@ -206,12 +206,12 @@ def download_datasource(domain, datasource_id):
         url=HqUrl.datasource_export_url(domain, datasource_id),
     )
     response = hq_request.get()
-
     if response.status_code != 200:
         raise CCHQApiException("Error downloading the UCR export from HQ")
 
     filename = f"{datasource_id}_{datetime.now()}.zip"
     path = os.path.join(superset.config.SHARED_DIR, filename)
+    breakpoint()
     with open(path, "wb") as f:
         f.write(response.content)
 

--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -3,7 +3,6 @@ import os
 from contextlib import contextmanager
 from datetime import date, datetime
 from zipfile import ZipFile
-from hq_superset.tasks import subscribe_to_hq_datasource_task
 
 import pandas
 import sqlalchemy
@@ -201,6 +200,7 @@ def get_datasource_file(path):
 def download_datasource(domain, datasource_id):
     import superset
     from hq_superset.hq_requests import HqUrl, HQRequest
+    from hq_superset.tasks import subscribe_to_hq_datasource_task
 
     hq_request = HQRequest(
         url=HqUrl.datasource_export_url(domain, datasource_id),

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -34,12 +34,12 @@ from .utils import (
     DomainSyncUtil,
     download_datasource,
     get_datasource_defn,
-    get_datasource_list_url,
     get_hq_database,
     get_schema_name_for_domain,
     refresh_hq_datasource,
     update_dataset,
 )
+from .hq_requests import HqUrl, HQRequest
 
 logger = logging.getLogger(__name__)
 
@@ -69,19 +69,14 @@ class HQDatasourceView(BaseSupersetView):
 
     @expose("/list/", methods=["GET"])
     def list_hq_datasources(self):
-        datasource_list_url = get_datasource_list_url(g.hq_domain)
-        provider = superset.appbuilder.sm.oauth_remotes["commcare"]
-        oauth_token = get_valid_cchq_oauth_token()
-        response = provider.get(datasource_list_url, token=oauth_token)
+        hq_request = HQRequest(url=HqUrl.datasource_list_url(g.hq_domain))
+        response = hq_request.get()
+
         if response.status_code == 403:
             return Response(status=403)
         if response.status_code != 200:
-            url = f"{provider.api_base_url}{datasource_list_url}"
-            return Response(
-                response="There was an error in fetching datasources from "
-                         f"CommCare HQ at {url}",
-                status=400,
-            )
+            url = hq_request.absolute_url
+            return Response(response=f"There was an error in fetching datasources from CommCareHQ at {url}", status=400)
         hq_datasources = response.json()
         for ds in hq_datasources['objects']:
             ds['is_import_in_progress'] = AsyncImportHelper(
@@ -91,7 +86,7 @@ class HQDatasourceView(BaseSupersetView):
             "hq_datasource_list.html",
             hq_datasources=hq_datasources,
             ucr_id_to_pks=self._ucr_id_to_pks(),
-            hq_base_url=provider.api_base_url,
+            hq_base_url=hq_request.api_base_url
         )
 
     @expose("/delete/<datasource_pk>", methods=["GET"])
@@ -122,12 +117,8 @@ def trigger_datasource_refresh(domain, datasource_id, display_name):
         )
         return redirect("/tablemodelview/list/")
 
-    provider = superset.appbuilder.sm.oauth_remotes["commcare"]
-    token = get_valid_cchq_oauth_token()
-    path, size = download_datasource(provider, token, domain, datasource_id)
-    datasource_defn = get_datasource_defn(
-        provider, token, domain, datasource_id
-    )
+    path, size = download_datasource(domain, datasource_id)
+    datasource_defn = get_datasource_defn(domain, datasource_id)
     if size < ASYNC_DATASOURCE_IMPORT_LIMIT_IN_BYTES:
         refresh_hq_datasource(
             domain, datasource_id, display_name, path, datasource_defn, None

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -247,8 +247,8 @@ class DataSetChangeAPI(BaseSupersetView):
 
         try:
             request_json = json.loads(request.get_data(as_text=True))
-            change = DataSetChange(**request_json)  # raises TypeError
-            update_dataset(change)  # raises ValueError
+            change = DataSetChange(**request_json)
+            # TODO: update_dataset(change)
             return self.json_response(
                 'Request accepted; updating dataset',
                 status=HTTPStatus.ACCEPTED.value,

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -233,7 +233,7 @@ class DataSetChangeAPI(BaseSupersetView):
         try:
             request_json = json.loads(request.get_data(as_text=True))
             change = DataSetChange(**request_json)
-            # TODO: update_dataset(change)
+            update_dataset(change)
             return self.json_response(
                 'Request accepted; updating dataset',
                 status=HTTPStatus.ACCEPTED.value,

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -40,6 +40,7 @@ from .utils import (
     update_dataset,
 )
 from .hq_requests import HqUrl, HQRequest
+from .api import require_oauth
 
 logger = logging.getLogger(__name__)
 
@@ -219,16 +220,9 @@ class DataSetChangeAPI(BaseSupersetView):
 
     # http://localhost:8088/hq_webhook/change/
     @expose_api(url='/change/', methods=('POST',))
-    # TODO: Authenticate
-    # e.g. superset.views.datasource.views.Datasource:
-    # @event_logger.log_this_with_context(
-    #     action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.save",
-    #     log_to_statsd=False,
-    # )
-    # @has_access_api
-    # @api
     @handle_api_exception
     @csrf.exempt
+    @require_oauth
     def post_dataset_change(self) -> FlaskResponse:
         if request.content_length > self.MAX_REQUEST_LENGTH:
             return json_error_response(

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'cryptography==37.0.4',
         'sentry-sdk==1.9.10',
         'celery==5.2.7',
+        'blinker==1.7.0',
     ],
     classifiers=[
         'Programming Language :: Python',

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -118,3 +118,4 @@ LANGUAGES = {
 OAUTH2_TOKEN_EXPIRES_IN = {
     'client_credentials': 86400,
 }
+BASE_URL = "http://localhost:5000"

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -114,3 +114,7 @@ LANGUAGES = {
    'en': {'flag':'us', 'name':'English'},
    'pt': {'flag':'pt', 'name':'Portuguese'}
 }
+
+OAUTH2_TOKEN_EXPIRES_IN = {
+    'client_credentials': 86400,
+}


### PR DESCRIPTION
Opening as draft since I'm busy checking how we can better manage migrations in this repo.

The changes introduced in this PR is as follows:
1. Add and invoke task to subscribe to a specific datasource on HQ
2. Adds a new API for handling OAuth with superset as the authorization server.
3. Add decorator (`require_oauth`) to check access token on `/hq_webhook/change/` endpoint.